### PR TITLE
update: add Claude 5 family and refresh Anthropic model statuses

### DIFF
--- a/manual_prices/Anthropic.yaml
+++ b/manual_prices/Anthropic.yaml
@@ -3,8 +3,35 @@ models:
     # 模型价格：https://platform.claude.com/docs/en/about-claude/pricing.md
     # 模型列表：https://platform.claude.com/docs/en/about-claude/models.md
 
-    # Claude 4.8 系列 - 最新一代模型（官方文档中也称 <NextOpus />）
-    # Note: Opus 4.7 and later use a new tokenizer which may use up to 35% more tokens for the same text
+    # Claude 5 系列 - 最新一代模型
+    # Note: Fable 5, Mythos 5, Sonnet 5, Opus 4.7+ use a newer tokenizer which produces ~30% more tokens for the same text
+    claude-fable-5:
+      aliases:
+        - claude-fable-5*
+      input: 10 usd / M
+      output: 50 usd / M
+      extra_ratios:
+        - cached_tokens: 1 usd / M
+
+    # Claude Mythos 5 - limited availability (Project Glasswing)
+    claude-mythos-5:
+      aliases:
+        - claude-mythos-5*
+      input: 10 usd / M
+      output: 50 usd / M
+      extra_ratios:
+        - cached_tokens: 1 usd / M
+
+    # Claude Sonnet 5 - introductory pricing through Aug 31, 2026; standard $3/$15 from Sep 1, 2026
+    claude-sonnet-5:
+      aliases:
+        - claude-sonnet-5*
+      input: 2 usd / M
+      output: 10 usd / M
+      extra_ratios:
+        - cached_tokens: 0.2 usd / M
+
+    # Claude 4.8 系列
     claude-opus-4-8:
       aliases:
         - claude-opus-4-8*
@@ -80,8 +107,9 @@ models:
       extra_ratios:
         - cached_tokens: 0.1 usd / M
 
-    # Claude 4.1 / 4.0 系列
+    # DEPRECATED: Claude Opus 4.1 将于 2026-08-05 退役，建议迁移到 Claude Opus 4.8
     claude-opus-4-1:
+      deprecated: 2026-08-05
       aliases:
         - claude-opus-4.1
         - claude-opus-4-1-20250805
@@ -91,9 +119,9 @@ models:
       extra_ratios:
         - cached_tokens: 1.5 usd / M
 
-    # DEPRECATED: Claude Opus 4 将于 2026-06-15 退役，建议迁移到 Claude Opus 4.7
+    # =========================== 已下线 ===========================
+    # RETIRED: Claude Opus 4 已于 2026-06-15 退役（仅 Google Cloud 仍可用），建议迁移到 Claude Opus 4.8
     claude-opus-4:
-      deprecated: 2026-06-15
       aliases:
         - claude-opus-4-20250514
         - claude-opus-4-0
@@ -104,9 +132,8 @@ models:
       extra_ratios:
         - cached_tokens: 1.5 usd / M
 
-    # DEPRECATED: Claude Sonnet 4 将于 2026-06-15 退役，建议迁移到 Claude Sonnet 4.6
+    # RETIRED: Claude Sonnet 4 已于 2026-06-15 退役（仅 Bedrock 和 Google Cloud 仍可用），建议迁移到 Claude Sonnet 4.6
     claude-sonnet-4:
-      deprecated: 2026-06-15
       aliases:
         - claude-sonnet-4-20250514
         - claude-sonnet-4-0
@@ -116,8 +143,6 @@ models:
       output: 15 usd / M
       extra_ratios:
         - cached_tokens: 0.3 usd / M
-
-    # =========================== 已下线 ===========================
     # RETIRED: Claude 3.7 Sonnet 已于 2026-02-19 退役，建议迁移到 Claude Sonnet 4.6
     claude-3-7-sonnet:
       aliases:

--- a/oneapi_prices.json
+++ b/oneapi_prices.json
@@ -1444,6 +1444,26 @@
       }
     },
     {
+      "model": "claude-fable-5",
+      "type": "tokens",
+      "channel_type": 14,
+      "input": 5.0,
+      "output": 25.0,
+      "extra_ratios": {
+        "cached_tokens": 0.1
+      }
+    },
+    {
+      "model": "claude-fable-5*",
+      "type": "tokens",
+      "channel_type": 14,
+      "input": 5.0,
+      "output": 25.0,
+      "extra_ratios": {
+        "cached_tokens": 0.1
+      }
+    },
+    {
       "model": "claude-haiku-4-5",
       "type": "tokens",
       "channel_type": 14,
@@ -1469,6 +1489,26 @@
       "channel_type": 14,
       "input": 0.5,
       "output": 2.5,
+      "extra_ratios": {
+        "cached_tokens": 0.1
+      }
+    },
+    {
+      "model": "claude-mythos-5",
+      "type": "tokens",
+      "channel_type": 14,
+      "input": 5.0,
+      "output": 25.0,
+      "extra_ratios": {
+        "cached_tokens": 0.1
+      }
+    },
+    {
+      "model": "claude-mythos-5*",
+      "type": "tokens",
+      "channel_type": 14,
+      "input": 5.0,
+      "output": 25.0,
       "extra_ratios": {
         "cached_tokens": 0.1
       }
@@ -1759,6 +1799,26 @@
       "channel_type": 14,
       "input": 1.5,
       "output": 7.5,
+      "extra_ratios": {
+        "cached_tokens": 0.1
+      }
+    },
+    {
+      "model": "claude-sonnet-5",
+      "type": "tokens",
+      "channel_type": 14,
+      "input": 1.0,
+      "output": 5.0,
+      "extra_ratios": {
+        "cached_tokens": 0.1
+      }
+    },
+    {
+      "model": "claude-sonnet-5*",
+      "type": "tokens",
+      "channel_type": 14,
+      "input": 1.0,
+      "output": 5.0,
       "extra_ratios": {
         "cached_tokens": 0.1
       }
@@ -4427,13 +4487,6 @@
       "output": 12.5
     },
     {
-      "model": "anthropic/claude-opus-4.6-fast",
-      "type": "tokens",
-      "channel_type": 20,
-      "input": 15.0,
-      "output": 75.0
-    },
-    {
       "model": "anthropic/claude-opus-4.7",
       "type": "tokens",
       "channel_type": 20,
@@ -4481,6 +4534,13 @@
       "channel_type": 20,
       "input": 1.5,
       "output": 7.5
+    },
+    {
+      "model": "anthropic/claude-sonnet-5",
+      "type": "tokens",
+      "channel_type": 20,
+      "input": 1.0,
+      "output": 5.0
     },
     {
       "model": "arcee-ai/coder-large",
@@ -4668,8 +4728,8 @@
       "model": "deepseek/deepseek-v4-flash",
       "type": "tokens",
       "channel_type": 20,
-      "input": 0.045,
-      "output": 0.09
+      "input": 0.049,
+      "output": 0.098
     },
     {
       "model": "deepseek/deepseek-v4-pro",
@@ -4764,6 +4824,13 @@
     },
     {
       "model": "google/gemini-3.1-flash-lite",
+      "type": "tokens",
+      "channel_type": 20,
+      "input": 0.125,
+      "output": 0.75
+    },
+    {
+      "model": "google/gemini-3.1-flash-lite-image",
       "type": "tokens",
       "channel_type": 20,
       "input": 0.125,
@@ -5064,13 +5131,6 @@
       "output": 0.07
     },
     {
-      "model": "microsoft/phi-4-mini-instruct",
-      "type": "tokens",
-      "channel_type": 20,
-      "input": 0.04,
-      "output": 0.175
-    },
-    {
       "model": "microsoft/wizardlm-2-8x22b",
       "type": "tokens",
       "channel_type": 20,
@@ -5298,8 +5358,8 @@
       "model": "moonshotai/kimi-k2.6",
       "type": "tokens",
       "channel_type": 20,
-      "input": 0.33,
-      "output": 1.705
+      "input": 0.275,
+      "output": 1.6
     },
     {
       "model": "moonshotai/kimi-k2.7-code",
@@ -5883,13 +5943,6 @@
       "output": 0.0
     },
     {
-      "model": "openrouter/owl-alpha",
-      "type": "tokens",
-      "channel_type": 20,
-      "input": 0.0,
-      "output": 0.0
-    },
-    {
       "model": "perceptron/perceptron-mk1",
       "type": "tokens",
       "channel_type": 20,
@@ -6033,8 +6086,8 @@
       "model": "qwen/qwen3-235b-a22b-thinking-2507",
       "type": "tokens",
       "channel_type": 20,
-      "input": 0.05,
-      "output": 0.05
+      "input": 0.07475,
+      "output": 0.7475
     },
     {
       "model": "qwen/qwen3-30b-a3b",
@@ -6257,8 +6310,8 @@
       "model": "qwen/qwen3.6-27b",
       "type": "tokens",
       "channel_type": 20,
-      "input": 0.14425,
-      "output": 1.325
+      "input": 0.1425,
+      "output": 1.2
     },
     {
       "model": "qwen/qwen3.6-35b-a3b",
@@ -6369,7 +6422,7 @@
       "model": "stepfun/step-3.5-flash",
       "type": "tokens",
       "channel_type": 20,
-      "input": 0.045,
+      "input": 0.05,
       "output": 0.15
     },
     {
@@ -6558,14 +6611,14 @@
       "model": "z-ai/glm-5.1",
       "type": "tokens",
       "channel_type": 20,
-      "input": 0.49,
-      "output": 1.54
+      "input": 0.4875,
+      "output": 2.15
     },
     {
       "model": "z-ai/glm-5.2",
       "type": "tokens",
       "channel_type": 20,
-      "input": 0.475,
+      "input": 0.465,
       "output": 1.5
     },
     {
@@ -6600,8 +6653,8 @@
       "model": "~anthropic/claude-sonnet-latest",
       "type": "tokens",
       "channel_type": 20,
-      "input": 1.5,
-      "output": 7.5
+      "input": 1.0,
+      "output": 5.0
     },
     {
       "model": "~google/gemini-flash-latest",
@@ -6621,8 +6674,8 @@
       "model": "~moonshotai/kimi-latest",
       "type": "tokens",
       "channel_type": 20,
-      "input": 0.33,
-      "output": 1.705
+      "input": 0.275,
+      "output": 1.6
     },
     {
       "model": "~openai/gpt-latest",
@@ -8878,6 +8931,13 @@
       "channel_type": 45,
       "input": 0.03571,
       "output": 0.14286
+    },
+    {
+      "model": "meituan-longcat/LongCat-2.0",
+      "type": "tokens",
+      "channel_type": 45,
+      "input": 0.35714,
+      "output": 1.42857
     },
     {
       "model": "moonshotai/Kimi-K2.7-Code",
@@ -11707,5 +11767,5 @@
       "output": 0.0
     }
   ],
-  "updated_at": "2026-06-27T09:43:56Z"
+  "updated_at": "2026-07-01T09:08:02Z"
 }

--- a/onehub_only_prices.json
+++ b/onehub_only_prices.json
@@ -1444,6 +1444,26 @@
       }
     },
     {
+      "model": "claude-fable-5",
+      "type": "tokens",
+      "channel_type": 14,
+      "input": 5.0,
+      "output": 25.0,
+      "extra_ratios": {
+        "cached_tokens": 0.1
+      }
+    },
+    {
+      "model": "claude-fable-5*",
+      "type": "tokens",
+      "channel_type": 14,
+      "input": 5.0,
+      "output": 25.0,
+      "extra_ratios": {
+        "cached_tokens": 0.1
+      }
+    },
+    {
       "model": "claude-haiku-4-5",
       "type": "tokens",
       "channel_type": 14,
@@ -1469,6 +1489,26 @@
       "channel_type": 14,
       "input": 0.5,
       "output": 2.5,
+      "extra_ratios": {
+        "cached_tokens": 0.1
+      }
+    },
+    {
+      "model": "claude-mythos-5",
+      "type": "tokens",
+      "channel_type": 14,
+      "input": 5.0,
+      "output": 25.0,
+      "extra_ratios": {
+        "cached_tokens": 0.1
+      }
+    },
+    {
+      "model": "claude-mythos-5*",
+      "type": "tokens",
+      "channel_type": 14,
+      "input": 5.0,
+      "output": 25.0,
       "extra_ratios": {
         "cached_tokens": 0.1
       }
@@ -1759,6 +1799,26 @@
       "channel_type": 14,
       "input": 1.5,
       "output": 7.5,
+      "extra_ratios": {
+        "cached_tokens": 0.1
+      }
+    },
+    {
+      "model": "claude-sonnet-5",
+      "type": "tokens",
+      "channel_type": 14,
+      "input": 1.0,
+      "output": 5.0,
+      "extra_ratios": {
+        "cached_tokens": 0.1
+      }
+    },
+    {
+      "model": "claude-sonnet-5*",
+      "type": "tokens",
+      "channel_type": 14,
+      "input": 1.0,
+      "output": 5.0,
       "extra_ratios": {
         "cached_tokens": 0.1
       }
@@ -4427,13 +4487,6 @@
       "output": 12.5
     },
     {
-      "model": "anthropic/claude-opus-4.6-fast",
-      "type": "tokens",
-      "channel_type": 20,
-      "input": 15.0,
-      "output": 75.0
-    },
-    {
       "model": "anthropic/claude-opus-4.7",
       "type": "tokens",
       "channel_type": 20,
@@ -4481,6 +4534,13 @@
       "channel_type": 20,
       "input": 1.5,
       "output": 7.5
+    },
+    {
+      "model": "anthropic/claude-sonnet-5",
+      "type": "tokens",
+      "channel_type": 20,
+      "input": 1.0,
+      "output": 5.0
     },
     {
       "model": "arcee-ai/coder-large",
@@ -4668,8 +4728,8 @@
       "model": "deepseek/deepseek-v4-flash",
       "type": "tokens",
       "channel_type": 20,
-      "input": 0.045,
-      "output": 0.09
+      "input": 0.049,
+      "output": 0.098
     },
     {
       "model": "deepseek/deepseek-v4-pro",
@@ -4764,6 +4824,13 @@
     },
     {
       "model": "google/gemini-3.1-flash-lite",
+      "type": "tokens",
+      "channel_type": 20,
+      "input": 0.125,
+      "output": 0.75
+    },
+    {
+      "model": "google/gemini-3.1-flash-lite-image",
       "type": "tokens",
       "channel_type": 20,
       "input": 0.125,
@@ -5064,13 +5131,6 @@
       "output": 0.07
     },
     {
-      "model": "microsoft/phi-4-mini-instruct",
-      "type": "tokens",
-      "channel_type": 20,
-      "input": 0.04,
-      "output": 0.175
-    },
-    {
       "model": "microsoft/wizardlm-2-8x22b",
       "type": "tokens",
       "channel_type": 20,
@@ -5298,8 +5358,8 @@
       "model": "moonshotai/kimi-k2.6",
       "type": "tokens",
       "channel_type": 20,
-      "input": 0.33,
-      "output": 1.705
+      "input": 0.275,
+      "output": 1.6
     },
     {
       "model": "moonshotai/kimi-k2.7-code",
@@ -5883,13 +5943,6 @@
       "output": 0.0
     },
     {
-      "model": "openrouter/owl-alpha",
-      "type": "tokens",
-      "channel_type": 20,
-      "input": 0.0,
-      "output": 0.0
-    },
-    {
       "model": "perceptron/perceptron-mk1",
       "type": "tokens",
       "channel_type": 20,
@@ -6033,8 +6086,8 @@
       "model": "qwen/qwen3-235b-a22b-thinking-2507",
       "type": "tokens",
       "channel_type": 20,
-      "input": 0.05,
-      "output": 0.05
+      "input": 0.07475,
+      "output": 0.7475
     },
     {
       "model": "qwen/qwen3-30b-a3b",
@@ -6257,8 +6310,8 @@
       "model": "qwen/qwen3.6-27b",
       "type": "tokens",
       "channel_type": 20,
-      "input": 0.14425,
-      "output": 1.325
+      "input": 0.1425,
+      "output": 1.2
     },
     {
       "model": "qwen/qwen3.6-35b-a3b",
@@ -6369,7 +6422,7 @@
       "model": "stepfun/step-3.5-flash",
       "type": "tokens",
       "channel_type": 20,
-      "input": 0.045,
+      "input": 0.05,
       "output": 0.15
     },
     {
@@ -6558,14 +6611,14 @@
       "model": "z-ai/glm-5.1",
       "type": "tokens",
       "channel_type": 20,
-      "input": 0.49,
-      "output": 1.54
+      "input": 0.4875,
+      "output": 2.15
     },
     {
       "model": "z-ai/glm-5.2",
       "type": "tokens",
       "channel_type": 20,
-      "input": 0.475,
+      "input": 0.465,
       "output": 1.5
     },
     {
@@ -6600,8 +6653,8 @@
       "model": "~anthropic/claude-sonnet-latest",
       "type": "tokens",
       "channel_type": 20,
-      "input": 1.5,
-      "output": 7.5
+      "input": 1.0,
+      "output": 5.0
     },
     {
       "model": "~google/gemini-flash-latest",
@@ -6621,8 +6674,8 @@
       "model": "~moonshotai/kimi-latest",
       "type": "tokens",
       "channel_type": 20,
-      "input": 0.33,
-      "output": 1.705
+      "input": 0.275,
+      "output": 1.6
     },
     {
       "model": "~openai/gpt-latest",
@@ -8878,6 +8931,13 @@
       "channel_type": 45,
       "input": 0.03571,
       "output": 0.14286
+    },
+    {
+      "model": "meituan-longcat/LongCat-2.0",
+      "type": "tokens",
+      "channel_type": 45,
+      "input": 0.35714,
+      "output": 1.42857
     },
     {
       "model": "moonshotai/Kimi-K2.7-Code",

--- a/openrouter_prices.json
+++ b/openrouter_prices.json
@@ -134,13 +134,6 @@
       "output": 12.5
     },
     {
-      "model": "anthropic/claude-opus-4.6-fast",
-      "type": "tokens",
-      "channel_type": 20,
-      "input": 15.0,
-      "output": 75.0
-    },
-    {
       "model": "anthropic/claude-opus-4.7",
       "type": "tokens",
       "channel_type": 20,
@@ -188,6 +181,13 @@
       "channel_type": 20,
       "input": 1.5,
       "output": 7.5
+    },
+    {
+      "model": "anthropic/claude-sonnet-5",
+      "type": "tokens",
+      "channel_type": 20,
+      "input": 1.0,
+      "output": 5.0
     },
     {
       "model": "arcee-ai/coder-large",
@@ -375,8 +375,8 @@
       "model": "deepseek/deepseek-v4-flash",
       "type": "tokens",
       "channel_type": 20,
-      "input": 0.045,
-      "output": 0.09
+      "input": 0.049,
+      "output": 0.098
     },
     {
       "model": "deepseek/deepseek-v4-pro",
@@ -471,6 +471,13 @@
     },
     {
       "model": "google/gemini-3.1-flash-lite",
+      "type": "tokens",
+      "channel_type": 20,
+      "input": 0.125,
+      "output": 0.75
+    },
+    {
+      "model": "google/gemini-3.1-flash-lite-image",
       "type": "tokens",
       "channel_type": 20,
       "input": 0.125,
@@ -771,13 +778,6 @@
       "output": 0.07
     },
     {
-      "model": "microsoft/phi-4-mini-instruct",
-      "type": "tokens",
-      "channel_type": 20,
-      "input": 0.04,
-      "output": 0.175
-    },
-    {
       "model": "microsoft/wizardlm-2-8x22b",
       "type": "tokens",
       "channel_type": 20,
@@ -1005,8 +1005,8 @@
       "model": "moonshotai/kimi-k2.6",
       "type": "tokens",
       "channel_type": 20,
-      "input": 0.33,
-      "output": 1.705
+      "input": 0.275,
+      "output": 1.6
     },
     {
       "model": "moonshotai/kimi-k2.7-code",
@@ -1590,13 +1590,6 @@
       "output": 0.0
     },
     {
-      "model": "openrouter/owl-alpha",
-      "type": "tokens",
-      "channel_type": 20,
-      "input": 0.0,
-      "output": 0.0
-    },
-    {
       "model": "perceptron/perceptron-mk1",
       "type": "tokens",
       "channel_type": 20,
@@ -1740,8 +1733,8 @@
       "model": "qwen/qwen3-235b-a22b-thinking-2507",
       "type": "tokens",
       "channel_type": 20,
-      "input": 0.05,
-      "output": 0.05
+      "input": 0.07475,
+      "output": 0.7475
     },
     {
       "model": "qwen/qwen3-30b-a3b",
@@ -1964,8 +1957,8 @@
       "model": "qwen/qwen3.6-27b",
       "type": "tokens",
       "channel_type": 20,
-      "input": 0.14425,
-      "output": 1.325
+      "input": 0.1425,
+      "output": 1.2
     },
     {
       "model": "qwen/qwen3.6-35b-a3b",
@@ -2076,7 +2069,7 @@
       "model": "stepfun/step-3.5-flash",
       "type": "tokens",
       "channel_type": 20,
-      "input": 0.045,
+      "input": 0.05,
       "output": 0.15
     },
     {
@@ -2265,14 +2258,14 @@
       "model": "z-ai/glm-5.1",
       "type": "tokens",
       "channel_type": 20,
-      "input": 0.49,
-      "output": 1.54
+      "input": 0.4875,
+      "output": 2.15
     },
     {
       "model": "z-ai/glm-5.2",
       "type": "tokens",
       "channel_type": 20,
-      "input": 0.475,
+      "input": 0.465,
       "output": 1.5
     },
     {
@@ -2307,8 +2300,8 @@
       "model": "~anthropic/claude-sonnet-latest",
       "type": "tokens",
       "channel_type": 20,
-      "input": 1.5,
-      "output": 7.5
+      "input": 1.0,
+      "output": 5.0
     },
     {
       "model": "~google/gemini-flash-latest",
@@ -2328,8 +2321,8 @@
       "model": "~moonshotai/kimi-latest",
       "type": "tokens",
       "channel_type": 20,
-      "input": 0.33,
-      "output": 1.705
+      "input": 0.275,
+      "output": 1.6
     },
     {
       "model": "~openai/gpt-latest",
@@ -2346,5 +2339,5 @@
       "output": 2.25
     }
   ],
-  "updated_at": "2026-06-27T09:43:55Z"
+  "updated_at": "2026-07-01T09:08:01Z"
 }

--- a/siliconflow_prices.json
+++ b/siliconflow_prices.json
@@ -547,6 +547,13 @@
       "output": 0.14286
     },
     {
+      "model": "meituan-longcat/LongCat-2.0",
+      "type": "tokens",
+      "channel_type": 45,
+      "input": 0.35714,
+      "output": 1.42857
+    },
+    {
       "model": "moonshotai/Kimi-K2.7-Code",
       "type": "tokens",
       "channel_type": 45,
@@ -603,5 +610,5 @@
       "output": 2.0
     }
   ],
-  "updated_at": "2026-06-27T09:43:54Z"
+  "updated_at": "2026-07-01T09:07:59Z"
 }


### PR DESCRIPTION
## Summary

- **Add 3 new models**: Claude Fable 5 ($10/$50/MTok), Claude Mythos 5 ($10/$50/MTok, limited availability), Claude Sonnet 5 ($2/$10/MTok introductory through Aug 31, 2026)
- **Deprecate**: Claude Opus 4.1 (retiring 2026-08-05)
- **Retire**: Claude Opus 4 and Claude Sonnet 4 (retired 2026-06-15, moved to 已下线 section)
- **Fix**: tokenizer note updated from 35% to ~30% per latest official docs

Source: https://platform.claude.com/docs/en/about-claude/pricing.md